### PR TITLE
Add row-specific paper size option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a Python desktop application for slicing large images into printable til
 - 🖨️ Output to image files **and/or** multipage PDF
 - 📐 Customizable tile size via preset or custom paper dimensions
 - 📏 Adjustable DPI, margins, and overlap
+- 🔀 Mix different paper sizes by specifying custom heights per row
 - 🎯 Corner and overlap alignment marks for easy trimming and matching
 - 🔍 Live preview of the first tile
 - 📁 Auto-opens output folder when finished

--- a/tests/test_draw_xs.py
+++ b/tests/test_draw_xs.py
@@ -63,6 +63,7 @@ def test_generate_tiles_creates_file(tmp_path, monkeypatch):
     app.custom_height_var = DummyVar(1)
     app.rows_var = DummyVar(1)
     app.cols_var = DummyVar(1)
+    app.row_heights_var = DummyVar("")
     app.border_in_var = DummyVar(0)
     app.overlap_in_var = DummyVar(0)
     app.corner_marks_var = DummyVar(False)


### PR DESCRIPTION
## Summary
- allow a comma-separated list of heights for each row
- update tiling logic to use variable row heights
- expose `row_heights_var` in GUI
- adjust tests for new property
- mention mixed paper sizes in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685033365f7c832fba582e78ec820494